### PR TITLE
Use ActiveStorage signed URLs with OVH S3

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,8 +13,6 @@ amazon:
   secret_access_key: <%= Rails.application.secrets.dig(:storage, :s3, :secret_access_key) %>
   region: <%= Rails.application.secrets.dig(:storage, :s3, :region) %>
   bucket: <%= Rails.application.secrets.dig(:storage, :s3, :bucket) %>
-  force_path_style: true
-  public: true
 
 azure:
   service: AzureStorage


### PR DESCRIPTION
Instead of having all files with public-read ACLs.

After removing the public option from active storage cofiguration the application started to generate signed URLs. With this method images or other files are accesible just when server through the application. Files are not directly accesible like previous installations.

In order to allow Direct Uploads set the bucket  CORS configuration to:

```
{
    "CORSRules": [
        {
            "AllowedHeaders": [
                "*"
            ],
            "AllowedMethods": [
                "GET",
                "POST",
                "PUT"
            ],
            "AllowedOrigins": [
                "https://the_application_domain_subdomain.com"
            ],
            "MaxAgeSeconds": 3000
        }
    ]
}
```

Initially I wante to use public read permission for anonymous users but I was not able to make it work. Each time I upload a file the global S3 bucket ACL does not apply to new uploads. I have to manually set the file public-read permission every time a new file is uploaded.

For using public setup add following ActiveStorage configuration to the amazon section (config/storage.yml):

```
  public: true
  upload:
    acl: "public-read"
```

I also tried to override some ActiveStorage methods to include the public-read permission during the file upload:

```
ActiveSupport.on_load(:active_storage_service) do
  ActiveStorage::Service::S3Service.class_eval do
    def upload(key, io, checksum: nil, **options)
      options[:acl] = "public-read"
      super(key, io, checksum: checksum, **options)
    end

    def presigned_post(key, **options)
      options[:acl] = "public-read"
      super(key, **options)
    end
  end
end
```

Nothing worked. 

IMO its better to use signed URLs so I stopped investigating.