### PR TITLE
Add minimum age restriction to census action authorizer

### DIFF
--- a/app/services/census_action_authorizer.rb
+++ b/app/services/census_action_authorizer.rb
@@ -3,19 +3,33 @@
 # It allows to set a list of valid
 # - districts
 # - district_councils
+# - minimum age
 # for an authorization.
 class CensusActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
-  attr_reader :allowed_districts, :allowed_district_councils
+  attr_reader :allowed_districts, :allowed_district_councils, :minimum_age
 
   # Overrides the parent class method, but it still uses it to keep the base behavior
   def authorize
     # Remove the additional setting from the options hash to avoid to be considered missing.
     @allowed_districts ||= options.delete("district")&.split(/[\W,;]+/)
     @allowed_district_councils ||= options.delete("district_council")&.split(/[\W,;]+/)
+    @minimum_age ||= options.delete("min_age")&.to_i
 
     status_code, data = *super
 
     extra_explanations = []
+    if minimum_age.present? && status_code == :ok
+      if authorized_birth_date.blank?
+        status_code = :incomplete
+        data = { fields: ["date_of_birth"], action: :reauthorize, cancel: true }
+      elsif authorized_age < minimum_age
+        status_code = :unauthorized
+        extra_explanations << { key: "extra_explanation.minimum_age",
+                                params: { scope: "decidim.verifications.census_authorization",
+                                          min_age: minimum_age } }
+      end
+    end
+
     if allowed_districts.present?
       # Does not authorize users with different districts
       if status_code == :ok && !allowed_districts.member?(authorization.metadata['district'])
@@ -45,5 +59,27 @@ class CensusActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
     data[:extra_explanation] = extra_explanations if extra_explanations.any?
 
     [status_code, data]
+  end
+
+  private
+
+  def authorized_birth_date
+    @authorized_birth_date ||= begin
+      raw_date = authorization.metadata["date_of_birth"]
+      Date.iso8601(raw_date) if raw_date.present?
+    rescue Date::Error
+      nil
+    end
+  end
+
+  def authorized_age
+    return nil if authorized_birth_date.blank?
+
+    now = Date.current
+    extra_year = (now.month > authorized_birth_date.month) || (
+      now.month == authorized_birth_date.month && now.day >= authorized_birth_date.day
+    )
+
+    now.year - authorized_birth_date.year - (extra_year ? 0 : 1)
   end
 end

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -32,6 +32,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
     {
       district_council: response["consellBarri"]&.strip,
       district: response["barri"]&.strip,
+      date_of_birth: date_of_birth&.iso8601,
       document_number: document_number,
     }
   end

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -420,6 +420,7 @@ Decidim::Verifications.register_workflow(:census_authorization_handler) do |auth
   auth.options do |options|
     options.attribute :district_council, type: :string, required: false
     options.attribute :district, type: :string, required: false
+    options.attribute :min_age, type: :integer, required: false
   end
 end
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -6,6 +6,7 @@ ca:
         district: Barri
         district_council: Consell de Barri
         document_number: Número de DNI
+        min_age: Edat mínima
   census_authorization:
     form:
       date_select:
@@ -28,6 +29,7 @@ ca:
           district: Barri
           district_council: Consell de Barri
           document_number: Número de document
+          min_age: Edat mínima
     verifications:
       id_documents:
         dni: DNI
@@ -55,3 +57,6 @@ ca:
         district_councils:
           one: La participació està restringida a les persones adscrites al consell de barri %{district_concils}.
           other: 'La participació està restringida a les persones adscrites a algun dels següents consells de barri: %{district_councils}.'
+        minimum_age:
+          one: La participació està restringida a les persones de %{min_age} anys o més.
+          other: La participació està restringida a les persones de %{min_age} anys o més.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -35,6 +35,9 @@ ca:
         dni: DNI
         nie: NIE
         passport: Passaport
+      census_authorization:
+        extra_explanation:
+          minimum_age: La participació està restringida a les persones de %{min_age} anys o més.
     shared:
       action_authorization_modal:
         expired:
@@ -57,6 +60,4 @@ ca:
         district_councils:
           one: La participació està restringida a les persones adscrites al consell de barri %{district_concils}.
           other: 'La participació està restringida a les persones adscrites a algun dels següents consells de barri: %{district_councils}.'
-        minimum_age:
-          one: La participació està restringida a les persones de %{min_age} anys o més.
-          other: La participació està restringida a les persones de %{min_age} anys o més.
+        minimum_age: La participació està restringida a les persones de %{min_age} anys o més.

--- a/spec/services/census_action_authorizer_spec.rb
+++ b/spec/services/census_action_authorizer_spec.rb
@@ -160,5 +160,40 @@ describe CensusActionAuthorizer do
           end
         end
     end
+
+    context "with min_age option" do
+      let(:options) { { 'min_age' => '65' } }
+
+      context "when the authorization includes a birth date for a user old enough" do
+        let(:authorization) { create(:authorization, :granted, user: user, metadata: { 'date_of_birth' => 66.years.ago.to_date.iso8601 }) }
+
+        it "grants authorization" do
+          expect(subject).to eq([:ok, {}])
+        end
+      end
+
+      context "when the authorization includes a birth date for a user that is too young" do
+        let(:authorization) { create(:authorization, :granted, user: user, metadata: { 'date_of_birth' => 64.years.ago.to_date.iso8601 }) }
+
+        it "doesn't grant authorization" do
+          expected_data = {
+            extra_explanation: [{
+              key: "extra_explanation.minimum_age",
+              params: { min_age: 65, scope: "decidim.verifications.census_authorization" }
+            }]
+          }
+
+          expect(subject).to eq([:unauthorized, expected_data])
+        end
+      end
+
+      context "when the authorization lacks the stored birth date" do
+        let(:authorization) { create(:authorization, :granted, user: user) }
+
+        it "asks the user to reauthorize" do
+          expect(subject).to eq([:incomplete, { fields: ["date_of_birth"], action: :reauthorize, cancel: true }])
+        end
+      end
+    end
   end
 end

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -85,6 +85,10 @@ describe CensusAuthorizationHandler do
       it "includes the district council" do
         expect(handler.metadata[:district_council]).to eq("1")
       end
+
+      it "includes the date of birth" do
+        expect(handler.metadata[:date_of_birth]).to eq("1987-09-17")
+      end
     end
 
     describe "document_number" do

--- a/spec/system/admin/participatory_process_component_permissions_spec.rb
+++ b/spec/system/admin/participatory_process_component_permissions_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Participatory process component permissions", type: :system do
+  let(:organization) do
+    create(
+      :organization,
+      default_locale: :ca,
+      available_locales: [:ca],
+      available_authorizations: ["census_authorization_handler"]
+    )
+  end
+
+  let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:participatory_process) { create(:participatory_process, organization: organization) }
+  let(:component) do
+    create(
+      :component,
+      manifest_name: "proposals",
+      participatory_space: participatory_process,
+      permissions: {
+        "vote" => {
+          "authorization_handlers" => {
+            "census_authorization_handler" => {
+              "options" => {
+                "district" => "",
+                "district_council" => ""
+              }
+            }
+          }
+        }
+      }
+    )
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+
+    admin_proxy = Decidim::EngineRouter.admin_proxy(participatory_process)
+    visit admin_proxy.edit_component_permissions_path(component_id: component.id)
+  end
+
+  it "stores min_age for census authorization handler" do
+    within ".vote-permission" do
+      find("input[name$='[min_age]']:not([disabled])", visible: :all).set("65")
+    end
+
+    within "form[id^='new_component_permissions']" do
+      click_button "Enviar"
+    end
+
+    expect(component.reload.permissions.dig("vote", "authorization_handlers", "census_authorization_handler", "options", "min_age")).to eq("65")
+  end
+end

--- a/spec/system/proposals_min_age_authorization_spec.rb
+++ b/spec/system/proposals_min_age_authorization_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "decidim/proposals/test/factories"
+
+describe "Proposals vote authorization by minimum age", type: :system, with_authorization_workflows: ["census_authorization_handler"] do
+  around do |example|
+    previous_server_port = Capybara.server_port
+    Capybara.server_port = 31_337
+    example.run
+  ensure
+    Capybara.server_port = previous_server_port
+  end
+
+  let(:organization) do
+    create(
+      :organization,
+      default_locale: :ca,
+      available_locales: [:ca],
+      available_authorizations: ["census_authorization_handler"]
+    )
+  end
+
+  let(:participatory_process) { create(:participatory_process, :with_steps, organization: organization, published_at: 1.day.ago) }
+  let(:component) do
+    create(
+      :proposal_component,
+      :with_votes_enabled,
+      participatory_space: participatory_process,
+      published_at: 1.day.ago,
+      permissions: {
+        "vote" => {
+          "authorization_handlers" => {
+            "census_authorization_handler" => {
+              "options" => {
+                "district" => "",
+                "district_council" => "",
+                "min_age" => "65"
+              }
+            }
+          }
+        }
+      }
+    )
+  end
+
+  let(:proposal) { create(:proposal, component: component, published_at: 1.day.ago) }
+  let(:user) { create(:user, :confirmed, locale: :ca, organization: organization) }
+
+  let!(:authorization) do
+    create(
+      :authorization,
+      name: CensusAuthorizationHandler.handler_name,
+      user: user,
+      granted_at: 2.seconds.ago,
+      metadata: {
+        "date_of_birth" => 64.years.ago.to_date.iso8601,
+        "district" => "",
+        "district_council" => ""
+      }
+    )
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit Decidim::ResourceLocatorPresenter.new(proposal).path
+  end
+
+  it "blocks voting actions restricted to 65+ users" do
+    within "#proposal-#{proposal.id}-vote-button" do
+      find("button, a", match: :first).click
+    end
+
+    expect(page).to have_content("65")
+    expect(page).to have_content("La participació està restringida a les persones de 65 anys o més")
+    expect(Decidim::Proposals::ProposalVote.where(proposal: proposal, author: user).count).to eq(0)
+  end
+end


### PR DESCRIPTION
### :tophat: What? Why?
El cliente necesita restringir la acción de voto en determinados procesos participativos a personas de 65 años o más. Decidim no incluye de serie este control a nivel de componente, por lo que se implementa como opción configurable del action authorizer del padrón municipal.

### References

This PR depends on:
* #13 

### Implementación

**Lógica de negocio**
- `CensusActionAuthorizer`: añade soporte para la opción `min_age` en los permisos del componente. Si la edad del usuario verificado es inferior al mínimo configurado, devuelve `:unauthorized` con mensaje explicativo. Si la metadata no contiene fecha de nacimiento, devuelve `:incomplete` solicitando re-autorización.
- `CensusAuthorizationHandler`: añade `date_of_birth` al hash de `metadata` para que el action authorizer pueda calcularlo.
- `config/initializers/decidim.rb`: registra la opción `min_age` (integer, opcional) en el workflow `census_authorization_handler`.

**Traducciones**
- `config/locales/ca.yml`: añade label `min_age` y mensaje de restricción `minimum_age` en los dos scopes usados por el modal de autorización.

### Tests
- Specs de servicio (`CensusActionAuthorizer`): casos de usuario con edad suficiente, insuficiente y sin fecha de nacimiento.
- Specs de servicio (`CensusAuthorizationHandler`): verifica que `date_of_birth` se incluye en metadata.
- Spec de sistema admin: guarda `min_age=65` en los permisos del componente desde la UI.
- Spec de sistema usuario final: usuario verificado de 64 años no puede votar en un proceso con restricción 65+.

### Cómo probarlo

1. En admin, ir a **Procesos → [proceso] → Componentes** → icono de llave (Permisos) del componente de propuestas.
2. Activar `census_authorization_handler` en la acción `vote` y establecer **Edat mínima = 65**.
3. Con un usuario verificado en el padrón y fecha de nacimiento < 65 años, intentar votar → se muestra el modal con el mensaje de restricción y el voto no se registra.

### Screenshots
<img width="1862" height="1920" alt="Screenshot from 2026-04-20 17-47-51" src="https://github.com/user-attachments/assets/99a282c4-f3c5-420e-89a6-9a2415a5f2b9" />
