### PR TITLE
fix: backport Decidim meeting copy taxonomy fix

### DIFF
--- a/config/initializers/decidim_copy_meeting_taxonomies.rb
+++ b/config/initializers/decidim_copy_meeting_taxonomies.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module DecidimCopyMeetingTaxonomies
+  private
+
+  def copy_meeting!
+    parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: meeting.organization).rewrite
+    parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.description, current_organization: meeting.organization).rewrite
+
+    @copied_meeting = Decidim.traceability.create!(
+      Decidim::Meetings::Meeting,
+      form.current_user,
+      taxonomizations: form.taxonomizations,
+      title: parsed_title,
+      description: parsed_description,
+      end_time: form.end_time,
+      start_time: form.start_time,
+      address: form.address,
+      latitude: form.latitude,
+      longitude: form.longitude,
+      location: form.location,
+      location_hints: form.location_hints,
+      component: meeting.component,
+      private_meeting: form.private_meeting,
+      transparent: form.transparent,
+      author: form.current_organization,
+      questionnaire: form.questionnaire,
+      online_meeting_url: form.online_meeting_url,
+      type_of_meeting: form.type_of_meeting,
+      iframe_embed_type: form.iframe_embed_type,
+      iframe_access_level: form.iframe_access_level,
+      comments_enabled: form.comments_enabled,
+      comments_start_time: form.comments_start_time,
+      comments_end_time: form.comments_end_time,
+      registration_type: form.registration_type,
+      registration_url: form.registration_url,
+      **fields_from_meeting
+    )
+  end
+end
+
+Rails.application.config.to_prepare do
+  next if Decidim::Meetings::Admin::CopyMeeting < DecidimCopyMeetingTaxonomies
+
+  Decidim::Meetings::Admin::CopyMeeting.prepend(DecidimCopyMeetingTaxonomies)
+end

--- a/spec/commands/decidim/meetings/admin/copy_meeting_taxonomies_spec.rb
+++ b/spec/commands/decidim/meetings/admin/copy_meeting_taxonomies_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Decidim::Meetings::Admin::CopyMeeting do
+  subject(:command) { described_class.new(form, meeting) }
+
+  let(:organization) { double("organization") }
+  let(:component) { double("component") }
+  let(:current_user) { double("current_user") }
+  let(:questionnaire) { double("questionnaire") }
+  let(:taxonomizations) { [double("taxonomization")] }
+  let(:meeting) do
+    double(
+      "meeting",
+      organization: organization,
+      component: component,
+      private_meeting: false,
+      transparent: true,
+      online_meeting_url: nil,
+      iframe_embed_type: "none",
+      iframe_access_level: "all",
+      comments_enabled: true,
+      comments_start_time: nil,
+      comments_end_time: nil,
+      registration_url: nil,
+      type_of_meeting: "online",
+      registrations_enabled: false,
+      available_slots: nil,
+      registration_terms: nil,
+      reserved_slots: nil,
+      customize_registration_email: false,
+      registration_form_enabled: false,
+      registration_email_custom_content: nil
+    )
+  end
+  let(:traceability) { double("traceability") }
+
+  let(:form) do
+    double(
+      invalid?: false,
+      title: { ca: "Reunio copiada" },
+      description: { ca: "Descripcio copiada" },
+      location: { ca: "Ubicacio" },
+      location_hints: { ca: "Pistes" },
+      start_time: 1.day.from_now,
+      end_time: 1.day.from_now + 1.hour,
+      address: "Carrer Major, 1",
+      latitude: 41.47,
+      longitude: 2.08,
+      taxonomizations: taxonomizations,
+      services_to_persist: [],
+      current_user: current_user,
+      questionnaire: questionnaire,
+      private_meeting: false,
+      transparent: true,
+      current_organization: organization,
+      online_meeting_url: nil,
+      iframe_embed_type: "none",
+      iframe_access_level: "all",
+      comments_enabled: true,
+      comments_start_time: nil,
+      comments_end_time: nil,
+      registration_type: "on_this_platform",
+      registration_url: nil,
+      type_of_meeting: "online"
+    )
+  end
+
+  before do
+    allow(Decidim).to receive(:traceability).and_return(traceability)
+    allow(Decidim::ContentProcessor).to receive(:parse_with_processor) do |_processor, content, current_organization:|
+      double(rewrite: content)
+    end
+  end
+
+  it "passes taxonomizations to the copied meeting creation" do
+    expect(traceability)
+      .to receive(:create!)
+      .with(
+        Decidim::Meetings::Meeting,
+        current_user,
+        hash_including(
+          taxonomizations: taxonomizations,
+          component: component,
+          questionnaire: questionnaire
+        )
+      )
+
+    command.send(:copy_meeting!)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Decidim 0.30.5 still uses the pre-fix CopyMeeting implementation, which passes taxonomies to traceability.create! and breaks meeting duplication when taxonomies are enabled after the taxonomy migration.

Backport the upstream Decidim fix locally by prepending CopyMeeting to send taxonomizations instead, and add a focused regression spec that locks the command behaviour.

**This is a temporary compatibility patch and should be removed once the app is upgraded to a Decidim version that already includes the upstream fix.**

#### Related issues and PRs

* https://github.com/decidim/decidim/issues/15718

* Backport to 0.31: https://github.com/decidim/decidim/pull/15745
* Fix in 0.32: https://github.com/decidim/decidim/pull/15736