### PR TITLE
Fix voting without registration

### DIFF
--- a/config/initializers/onboarding_manager_override.rb
+++ b/config/initializers/onboarding_manager_override.rb
@@ -1,19 +1,23 @@
-# Baseline override copied from Decidim 0.30.5 to keep a clean diff for the patch.
+# Defensive backport for Decidim 0.30.x onboarding flow.
+# Keeps behavior close to upstream while avoiding crashes when user is nil
+# (e.g. verify_wo_registration paths reached without signed-in user).
 
 module Decidim
-  module OnboardingManager0305Base
+  module OnboardingManagerDefensiveBackport
     private
 
-    # Copied from Decidim::OnboardingManager#onboarding_data (v0.30.5)
     def onboarding_data
-      user.extended_data[Decidim::OnboardingManager::DATA_KEY] || {}
+      return {} if user.blank?
+
+      data = user.extended_data[Decidim::OnboardingManager::DATA_KEY]
+      data.is_a?(Hash) ? data : {}
     end
 
     public
 
-    # Copied from Decidim::OnboardingManager#valid? (v0.30.5)
     def valid?
-      return if action.blank?
+      return false if user.blank?
+      return false if action.blank?
 
       permissions_holder.present?
     end
@@ -22,6 +26,6 @@ end
 
 Rails.application.config.to_prepare do
   if defined?(Decidim::OnboardingManager)
-    Decidim::OnboardingManager.prepend(Decidim::OnboardingManager0305Base)
+    Decidim::OnboardingManager.prepend(Decidim::OnboardingManagerDefensiveBackport)
   end
 end

--- a/config/initializers/onboarding_manager_override.rb
+++ b/config/initializers/onboarding_manager_override.rb
@@ -1,0 +1,27 @@
+# Baseline override copied from Decidim 0.30.5 to keep a clean diff for the patch.
+
+module Decidim
+  module OnboardingManager0305Base
+    private
+
+    # Copied from Decidim::OnboardingManager#onboarding_data (v0.30.5)
+    def onboarding_data
+      user.extended_data[Decidim::OnboardingManager::DATA_KEY] || {}
+    end
+
+    public
+
+    # Copied from Decidim::OnboardingManager#valid? (v0.30.5)
+    def valid?
+      return if action.blank?
+
+      permissions_holder.present?
+    end
+  end
+end
+
+Rails.application.config.to_prepare do
+  if defined?(Decidim::OnboardingManager)
+    Decidim::OnboardingManager.prepend(Decidim::OnboardingManager0305Base)
+  end
+end

--- a/config/initializers/verify_wo_registration_min_age.rb
+++ b/config/initializers/verify_wo_registration_min_age.rb
@@ -1,0 +1,37 @@
+# Baseline override copied from Decidim 0.30.5 to keep a clean diff for the patch.
+
+module Decidim
+  module VerifyWoRegistration
+    module VerificationsController0305Base
+      # Copied from Decidim::VerifyWoRegistration::VerificationsController#create (v0.30.5)
+      def create
+        @form = form(VerifyWoRegistrationForm).from_params(form_params)
+
+        DoVerifyWoRegistration.call(@form) do
+          on(:ok) do |user|
+            flash[:notice] = I18n.t("verify_wo_registration.create.success", minutes: ::Decidim::ImpersonationLog::SESSION_TIME_IN_MINUTES)
+
+            sign_in(user)
+            redirect_to @form.redirect_url
+          end
+
+          on(:use_registered_user) do
+            flash.now[:alert] = I18n.t("verify_wo_registration.create.use_registered_user")
+            render :new
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("impersonations.create.error", scope: "decidim.admin")
+            render :new
+          end
+        end
+      end
+    end
+  end
+end
+
+Rails.application.config.to_prepare do
+  if defined?(Decidim::VerifyWoRegistration::VerificationsController)
+    Decidim::VerifyWoRegistration::VerificationsController.prepend(Decidim::VerifyWoRegistration::VerificationsController0305Base)
+  end
+end

--- a/config/initializers/verify_wo_registration_min_age.rb
+++ b/config/initializers/verify_wo_registration_min_age.rb
@@ -1,9 +1,72 @@
-# Baseline override copied from Decidim 0.30.5 to keep a clean diff for the patch.
+# Enforce min_age in verify_wo_registration without forcing account registration.
+# The age check is applied on form submission using verification metadata.
 
 module Decidim
   module VerifyWoRegistration
-    module VerificationsController0305Base
-      # Copied from Decidim::VerifyWoRegistration::VerificationsController#create (v0.30.5)
+    module MinAgeFormValidation
+      extend ActiveSupport::Concern
+
+      included do
+        validate :validate_minimum_age_for_vote
+      end
+
+      private
+
+      def validate_minimum_age_for_vote
+        return if errors.any?
+
+        min_age = minimum_age_for_vote
+        return unless min_age.positive?
+
+        birth_date = authorization_birth_date
+        if birth_date.blank?
+          errors.add(:authorizations, :minimum_age_not_met, min_age: min_age)
+          return
+        end
+
+        errors.add(:authorizations, :minimum_age_not_met, min_age: min_age) if age_for(birth_date) < min_age
+      end
+
+      def minimum_age_for_vote
+        handlers = component.permissions.dig("vote", "authorization_handlers")
+        return 0 unless handlers.respond_to?(:values)
+
+        handlers.values.filter_map do |handler|
+          min_age = handler.dig("options", "min_age").to_i
+          min_age if min_age.positive?
+        end.max.to_i
+      end
+
+      def authorization_birth_date
+        authorization_handlers.each do |handler|
+          next unless handler.respond_to?(:metadata)
+
+          metadata = handler.metadata
+          next if metadata.blank?
+
+          raw_date = metadata["date_of_birth"] || metadata[:date_of_birth]
+          next if raw_date.blank?
+
+          parsed = Date.iso8601(raw_date.to_s)
+          return parsed if parsed
+        rescue Date::Error, ArgumentError
+          next
+        end
+
+        nil
+      end
+
+      def age_for(birth_date)
+        now = Date.current
+        extra_year = (now.month > birth_date.month) || (
+          now.month == birth_date.month && now.day >= birth_date.day
+        )
+
+        now.year - birth_date.year - (extra_year ? 0 : 1)
+      end
+    end
+
+    module MinAgeInvalidAlert
       def create
         @form = form(VerifyWoRegistrationForm).from_params(form_params)
 
@@ -21,17 +84,31 @@ module Decidim
           end
 
           on(:invalid) do
-            flash.now[:alert] = I18n.t("impersonations.create.error", scope: "decidim.admin")
+            flash.now[:alert] = if min_age_restriction_error?
+                                  I18n.t("decidim.verify_wo_registration.min_age_restricted")
+                                else
+                                  I18n.t("impersonations.create.error", scope: "decidim.admin")
+                                end
             render :new
           end
         end
+      end
+
+      private
+
+      def min_age_restriction_error?
+        @form.errors.details.fetch(:authorizations, []).any? { |error| error[:error] == :minimum_age_not_met }
       end
     end
   end
 end
 
 Rails.application.config.to_prepare do
+  if defined?(Decidim::VerifyWoRegistration::VerifyWoRegistrationForm)
+    Decidim::VerifyWoRegistration::VerifyWoRegistrationForm.include(Decidim::VerifyWoRegistration::MinAgeFormValidation)
+  end
+
   if defined?(Decidim::VerifyWoRegistration::VerificationsController)
-    Decidim::VerifyWoRegistration::VerificationsController.prepend(Decidim::VerifyWoRegistration::VerificationsController0305Base)
+    Decidim::VerifyWoRegistration::VerificationsController.prepend(Decidim::VerifyWoRegistration::MinAgeInvalidAlert)
   end
 end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -51,6 +51,8 @@ ca:
           explanation: Per dur a terme aquesta acció, has d'estar autoritzat/da amb el padró municipal.
         unauthorized:
           invalid_field: "%{field} no és correcte"
+    verify_wo_registration:
+       min_age_restricted: Ho sentim, la teva edat és inferior a la requerida per a aquesta activitat.
   verifications:
     census_authorization:
       extra_explanation:

--- a/spec/system/proposals_min_age_authorization_spec.rb
+++ b/spec/system/proposals_min_age_authorization_spec.rb
@@ -22,58 +22,137 @@ describe "Proposals vote authorization by minimum age", type: :system, with_auth
   end
 
   let(:participatory_process) { create(:participatory_process, :with_steps, organization: organization, published_at: 1.day.ago) }
-  let(:component) do
-    create(
-      :proposal_component,
-      :with_votes_enabled,
-      participatory_space: participatory_process,
-      published_at: 1.day.ago,
-      permissions: {
-        "vote" => {
-          "authorization_handlers" => {
-            "census_authorization_handler" => {
-              "options" => {
-                "district" => "",
-                "district_council" => "",
-                "min_age" => "65"
+
+  before do
+    allow_any_instance_of(CensusAuthorizationHandler).to receive(:response).and_return({ "res" => 1, "barri" => "", "consellBarri" => "" })
+    allow(Decidim::VerifyWoRegistration::ApplicationHelper).to receive(:verify_wo_registration_custom_modal?).and_return(true)
+    switch_to_host(organization.host)
+  end
+
+  context "when a registered user with age restriction votes" do
+    let(:component) do
+      create(
+        :proposal_component,
+        :with_votes_enabled,
+        participatory_space: participatory_process,
+        published_at: 1.day.ago,
+        permissions: {
+          "vote" => {
+            "authorization_handlers" => {
+              "census_authorization_handler" => {
+                "options" => {
+                  "district" => "",
+                  "district_council" => "",
+                  "min_age" => "65"
+                }
               }
             }
           }
         }
-      }
-    )
-  end
-
-  let(:proposal) { create(:proposal, component: component, published_at: 1.day.ago) }
-  let(:user) { create(:user, :confirmed, locale: :ca, organization: organization) }
-
-  let!(:authorization) do
-    create(
-      :authorization,
-      name: CensusAuthorizationHandler.handler_name,
-      user: user,
-      granted_at: 2.seconds.ago,
-      metadata: {
-        "date_of_birth" => 64.years.ago.to_date.iso8601,
-        "district" => "",
-        "district_council" => ""
-      }
-    )
-  end
-
-  before do
-    switch_to_host(organization.host)
-    login_as user, scope: :user
-    visit Decidim::ResourceLocatorPresenter.new(proposal).path
-  end
-
-  it "blocks voting actions restricted to 65+ users" do
-    within "#proposal-#{proposal.id}-vote-button" do
-      find("button, a", match: :first).click
+      )
     end
 
-    expect(page).to have_content("65")
-    expect(page).to have_content("La participació està restringida a les persones de 65 anys o més")
-    expect(Decidim::Proposals::ProposalVote.where(proposal: proposal, author: user).count).to eq(0)
+    let(:proposal) { create(:proposal, component: component, published_at: 1.day.ago) }
+    let(:user) { create(:user, :confirmed, locale: :ca, organization: organization) }
+
+    let!(:authorization) do
+      create(
+        :authorization,
+        name: CensusAuthorizationHandler.handler_name,
+        user: user,
+        granted_at: 2.seconds.ago,
+        metadata: {
+          "date_of_birth" => 64.years.ago.to_date.iso8601,
+          "district" => "",
+          "district_council" => ""
+        }
+      )
+    end
+
+    before do
+      login_as user, scope: :user
+      visit Decidim::ResourceLocatorPresenter.new(proposal).path
+    end
+
+    it "blocks voting actions restricted to 65+ users" do
+      within "#proposal-#{proposal.id}-vote-button" do
+        find("button, a", match: :first).click
+      end
+
+      expect(page).to have_content("65")
+      expect(page).to have_content("La participació està restringida a les persones de 65 anys o més")
+      expect(Decidim::Proposals::ProposalVote.where(proposal: proposal, author: user).count).to eq(0)
+    end
+  end
+
+  context "when an unregistered visitor votes without age restriction" do
+    let(:component) do
+      create(
+        :proposal_component,
+        :with_votes_enabled,
+        participatory_space: participatory_process,
+        published_at: 1.day.ago,
+        permissions: {
+          "vote" => {
+            "authorization_handlers" => {
+              "census_authorization_handler" => {
+                "options" => {
+                  "district" => "",
+                  "district_council" => "",
+                  "min_age" => "65"
+                }
+              }
+            }
+          }
+        }
+      )
+    end
+
+    let(:verify_wo_registration_path) do
+      Decidim::VerifyWoRegistration::Engine.routes.url_helpers.new_verification_path(
+        component_id: component.id,
+        redirect_url: Decidim::ResourceLocatorPresenter.new(participatory_process).path,
+        votable_gid: "gid://decidim/Dummy/1"
+      )
+    end
+
+    context "when the visitor is underage" do
+      it "blocks the verification and prevents voting" do
+        expect(Decidim::User.where(organization: organization, managed: true).count).to eq(0)
+        expect(Decidim::Authorization.where(name: CensusAuthorizationHandler.handler_name).count).to eq(0)
+
+        expect { visit verify_wo_registration_path }.not_to raise_error
+
+        find("input[name*='[document_number]']").set("12345678A")
+        find("select[name*='[date_of_birth(3i)]'] option[value='12']").select_option
+        find("select[name*='[date_of_birth(2i)]'] option[value='1']").select_option
+        find("select[name*='[date_of_birth(1i)]'] option[value='2000']").select_option
+        find("form[action='#{decidim_verify_wo_registration.verifications_path}'] button[type='submit']", match: :first).click
+
+        expect(page).to have_current_path(decidim_verify_wo_registration.verifications_path, ignore_query: true)
+        expect(page).to have_content("Ho sentim, la teva edat és inferior a la requerida per a aquesta activitat.")
+        expect(Decidim::User.where(organization: organization, managed: true).count).to eq(0)
+        expect(Decidim::Authorization.where(name: CensusAuthorizationHandler.handler_name).count).to eq(0)
+      end
+    end
+
+    context "when the visitor meets the minimum age" do
+      it "allows verification and creates a vote session" do
+        expect(Decidim::User.where(organization: organization, managed: true).count).to eq(0)
+        expect(Decidim::Authorization.where(name: CensusAuthorizationHandler.handler_name).count).to eq(0)
+
+        expect { visit verify_wo_registration_path }.not_to raise_error
+
+        find("input[name*='[document_number]']").set("12345678A")
+        find("select[name*='[date_of_birth(3i)]'] option[value='12']").select_option
+        find("select[name*='[date_of_birth(2i)]'] option[value='1']").select_option
+        find("select[name*='[date_of_birth(1i)]'] option[value='1955']").select_option
+        find("form[action='#{decidim_verify_wo_registration.verifications_path}'] button[type='submit']", match: :first).click
+
+        expect(page).to have_current_path(Decidim::ResourceLocatorPresenter.new(participatory_process).path, ignore_query: true)
+        expect(Decidim::User.where(organization: organization, managed: true).count).to eq(1)
+        expect(Decidim::Authorization.where(name: CensusAuthorizationHandler.handler_name).count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Resumen

Este PR corrige un error 500 en el flujo de verificación sin registro y añade la validación de la edad mínima para votar, sin romper la filosofía de Decidim Sant Cugat de permitir la participación sin cuenta registrada.

## Problema

En nuestra instalación (Decidim 0.30.5), cuando una persona no registrada accede al flujo de `verify_wo_registration` y existe lógica de autorizaciones pendiente, se puede producir un error 500:

`undefined method 'extended_data' for nil` en `OnboardingManager`

Además, la restricción de `min_age` no se aplicaba en el flujo de verificación sin registro, por lo que ese requisito solo quedaba cubierto cuando el usuario había iniciado sesión con su cuenta de Decidim Sant Cugat.

## Solución aplicada

### 1. Parche defensivo en `OnboardingManager`

Se añade un override defensivo para evitar accesos a `user.extended_data` cuando `user` o `action` son `nil`.

Esto evita el 500 en el flujo de `verify_wo_registration`.

### 2. Validación de edad mínima en `verify_wo_registration`

Se añade una validación específica para aplicar `min_age` al envío del formulario de verificación sin registro.

El comportamiento resultante es:

- Si la persona no cumple la edad mínima, la verificación se rechaza y se muestra un mensaje de error.
- Si la cumple, el flujo continúa de forma habitual y puede votar sin registrarse.

### 3. Mensaje de error específico

Se añade la traducción al catalán en el caso de edad insuficiente:

`Ho sentim, la teva edat és inferior a la requerida per a aquesta activitat.`

## Separación de cambios

Los cambios se han separado en dos bloques funcionales independientes:

1. **Parche defensivo de onboarding**
   - Corrige el error 500 en el flujo sin registro.

2. **Personalización local de `min_age`**
   - Añade la validación de la edad mínima en `verify_wo_registration`.

Esta separación facilita la revisión y permitirá revertir o mantener cada parte de forma independiente en el futuro.

## Sobre la relación con Decidim upstream

Este PR **no es un backport directo de un commit concreto de Decidim**.

Lo que hacemos aquí es:

- aplicar un **parche local defensivo** sobre `OnboardingManager` para evitar un bug funcional en nuestro caso de uso
- añadir una **personalización local** para hacer cumplir `min_age` en el flujo de verificación sin registro

Durante el análisis se revisó el trabajo upstream relacionado con onboarding y flujos de verificación:

- PR: https://github.com/decidim/decidim/pull/13295
- Issue relacionada: https://github.com/decidim/decidim/issues/13038

Ese trabajo sirve como contexto funcional, pero el parche incluido en esta PR se ajusta a nuestra instalación y a nuestro caso concreto.

## Validación

Se han incorporado tests de sistema cubriendo estos escenarios:

- Usuario registrado menor de edad: voto bloqueado.
- Visitante no registrado, menor de edad: verificación rechazada con un mensaje específico.
- Visitante no registrado con edad válida: verificación y flujo de voto permitidos.

## Impacto esperado

- Se elimina el error 500 en staging para el flujo sin registro.
- Se aplica la restricción de edad mínima de forma coherente también en `verify_wo_registration`.
- Se mantiene la experiencia de participación sin registro cuando la persona cumple con las condiciones requeridas.

## Deuda técnica

### Parche defensivo de onboarding

El fichero `config/initializers/onboarding_manager_override.rb` es un parche local defensivo.

Conviene revisar en futuras actualizaciones de Decidim si el bug funcional queda resuelto en el upstream. Si eso ocurre, este initializer debería eliminarse para volver al comportamiento estándar del framework.

### Validación de edad mínima

El fichero `config/initializers/verify_wo_registration_min_age.rb` es una personalización local vinculada a nuestras reglas de negocio.

No responde a un fix upstream conocido, así que debe considerarse una adaptación propia de la aplicación y mantenerse mientras queramos exigir `min_age` también en el flujo de verificación sin registro.