### PR TITLE
fix(editor): preserve legacy images in WYSIWYG

### DIFF
--- a/config/initializers/decidim_editor_legacy_images.rb
+++ b/config/initializers/decidim_editor_legacy_images.rb
@@ -1,0 +1,84 @@
+# Defensive backport for Decidim 0.30.x rich text editor.
+# Legacy HTML stores standalone <img> tags while the new Tiptap editor
+# rehydrates images only when they are wrapped in `div[data-image]`.
+
+module Decidim
+  module LegacyEditorImageNormalizer
+    module_function
+
+    def normalize(content)
+      case content
+      when Hash
+        content.transform_values { |value| normalize(value) }
+      when String
+        return content unless content.include?("<img")
+
+        fragment = Nokogiri::HTML::DocumentFragment.parse(content)
+        changed = normalize_image_paragraphs(fragment)
+
+        fragment.css("img[src]:not([src^='data:'])").each do |image|
+          next if image.ancestors.any? { |ancestor| ancestor.element? && ancestor.key?("data-image") }
+
+          image.replace(build_editor_image_wrapper(image.dup, fragment.document))
+          changed = true
+        end
+
+        changed ? fragment.to_html : content
+      else
+        content
+      end
+    end
+
+    def normalize_image_paragraphs(fragment)
+      changed = false
+
+      fragment.css("p").each do |paragraph|
+        next if paragraph.ancestors.any? { |ancestor| ancestor.element? && ancestor.key?("data-image") }
+
+        images = paragraph.css("img[src]:not([src^='data:'])")
+        next if images.empty?
+
+        meaningful_children = paragraph.children.reject { |node| node.text? && node.text.strip.empty? }
+        next unless meaningful_children.all? { |node| images.include?(node) }
+
+        replacement = Nokogiri::HTML::DocumentFragment.parse("")
+        images.each do |image|
+          replacement.add_child(build_editor_image_wrapper(image.dup, fragment.document))
+        end
+
+        paragraph.replace(replacement)
+        changed = true
+      end
+
+      changed
+    end
+
+    def build_editor_image_wrapper(image, document)
+      wrapper = Nokogiri::XML::Node.new("div", document)
+      wrapper["class"] = "editor-content-image"
+      wrapper["data-image"] = ""
+      wrapper.add_child(image)
+      wrapper
+    end
+  end
+
+  module FormBuilderLegacyEditorImages
+    def editor(name, options = {})
+      value = if options.key?(:value)
+        options[:value]
+      elsif object.respond_to?(name)
+        object.public_send(name)
+      end
+
+      return super(name, options) unless value.is_a?(String) || value.is_a?(Hash)
+
+      super(name, options.merge(value: LegacyEditorImageNormalizer.normalize(value)))
+    end
+  end
+end
+
+Rails.application.config.to_prepare do
+  if defined?(Decidim::FormBuilder)
+    Decidim::FormBuilder.prepend(Decidim::FormBuilderLegacyEditorImages)
+  end
+end

--- a/spec/system/admin/accountability_result_legacy_images_spec.rb
+++ b/spec/system/admin/accountability_result_legacy_images_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "decidim/accountability/test/factories"
+
+describe "Admin edits accountability results with legacy remote images", type: :system, js: true do
+  let(:organization) do
+    create(
+      :organization,
+      default_locale: :ca,
+      available_locales: [:ca]
+    )
+  end
+
+  let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:participatory_process) { create(:participatory_process, :with_steps, organization: organization) }
+  let(:component) { create(:accountability_component, participatory_space: participatory_process) }
+  let(:result_status) { create(:status, component: component, name: { ca: "En curs" }) }
+
+  let(:description_html) do
+    <<~HTML.gsub(/\n\s*/, "")
+      <ul><li><strong>Descripció</strong>:&nbsp;Posar nous elements de joc infanttil i una prègola vegetal a l’espai que hi ha a tocar del passeig del Roser.</li><li><strong>Ubicació</strong>:&nbsp;Casal Mira-sol</li><li><strong>Pressupost</strong>:&nbsp;25.000 euros.</li><li><strong>Objectiu</strong>: Millorar l’oferta de jocs infantils a l’exterior del Casal.</li></ul><p><img border="0" data-original-height="1200" data-original-width="1600" src="https://1.bp.blogspot.com/-3k1rWVNVEWI/XeZXYB_xAaI/AAAAAAAAC9g/uIkHBypXIsEybZKwMF2BfnRMy9iqsnO9wCLcBGAsYHQ/s1600/WhatsApp%2BImage%2B2019-12-03%2Bat%2B11.56.57.jpeg"></p><p><strong>3 de desembre del 2019. Projecte executat:</strong></p><p>A principis de desembre, ja hi ha la pèrgola vegetal i tots els jocs instal·lats i a punt per utilitzar. Només falta acabar de relligar les branques de la pèrgola.</p><p><img border="0" data-original-height="900" data-original-width="1600" src="https://1.bp.blogspot.com/-k3xm0TEYUdE/XeZT34NgETI/AAAAAAAAC9A/ET2WonxjTgMGbmPSV932qEa5MXRaN82VgCLcBGAsYHQ/s1600/20191203_103036.jpg"></p><p><img border="0" data-original-height="900" data-original-width="1600" src="https://1.bp.blogspot.com/-dkdrJn-TlCA/XeZTyQzyn2I/AAAAAAAAC84/qqBpYeEUFt48oAuzdDxBXzir-a31uQvWACLcBGAsYHQ/s1600/20191203_103006.jpg"></p><p><strong>18 de novembre del 2019. Comencen els treballs</strong>:</p><p>A mitjans de novembre, comencen les obres per instal·lar els nous elements de joc a tocar de la nova pèrgola vegetal. Els trreballs s'allarguen fins a finals de mes.</p><p><img border="0" data-original-height="900" data-original-width="1600" src="https://1.bp.blogspot.com/-iVB9lqOG-Us/XeZTmNczCMI/AAAAAAAAC8w/4LeVPadJIwwLZWWFzeb_q-3m3ndu1Q-qACLcBGAsYHQ/s1600/20191127_093259.jpg"></p><p><img border="0" data-original-height="900" data-original-width="1600" src="https://1.bp.blogspot.com/-tVl042DWHW8/XeZTeIgu02I/AAAAAAAAC8s/kOXjh9m2_i4u61cQSDag2QnAXmQTLptIACLcBGAsYHQ/s1600/20191126_101833.jpg"></p><p><strong>Maig de 2019. S'acaba de definir el projecte:</strong></p><p>Es proposa posar més elements de joc infantil a la zona que hi ha a tocar del passeig del Roser. Concretament, el projecte preveu instal·lar:</p><ul><li>Un gronxador de cistella.</li><li>Dos elements de molles.</li><li>Un element giratori.</li><li>Bancs per seure</li><li>Jocs d’equilibri fets amb troncs.</li><li>Ampliar el sorral actual i cobrir-lo amb una pèrgola vegetal que garanteixi que l'espai tingui ombra.</li></ul><p><img border="0" data-original-height="1324" data-original-width="1600" src="https://1.bp.blogspot.com/-bMdtxWww4YM/XdKH73biltI/AAAAAAAAC18/07EtiBMp_4I60zrgH_Fxf7WFck3g_BAZgCLcBGAsYHQ/s1600/CASAL_planta%2Bjocs.jpg"></p><p><img border="0" data-original-height="898" data-original-width="1600" src="https://1.bp.blogspot.com/-4J1e_m0Hj28/XeZTCXQYL_I/AAAAAAAAC8k/6O0e3qDxhmQ7XOoVDea95p1KZZzb4q_DgCLcBGAsYHQ/s1600/1.JPG"></p>
+    HTML
+  end
+
+  let!(:result) do
+    create(
+      :result,
+      component: component,
+      status: result_status,
+      title: { ca: "Jocs infantils Casal Mira-sol" },
+      description: { ca: description_html }
+    )
+  end
+
+  let(:expected_image_sources) do
+    Nokogiri::HTML::DocumentFragment.parse(description_html).css("img[src]").map { |image| image["src"] }
+  end
+
+  let(:component_admin_path) do
+    Decidim::EngineRouter.admin_proxy(component).root_path
+  end
+
+  let(:description_editor_selector) { "#result_description_ca" }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+  end
+
+  it "rehydrates all legacy remote images in the editor" do
+    visit component_admin_path
+
+    within "tr[data-id='#{result.id}'] .table-list__actions" do
+      find("a.action-icon--edit").click
+    end
+
+    within description_editor_selector do
+      expect(page).to have_css(".editor-input .ProseMirror")
+      expect(page).to have_css(".editor-input .ProseMirror img[src]", count: expected_image_sources.count)
+    end
+
+    expect(editor_image_sources).to eq(expected_image_sources)
+  end
+
+  def editor_image_sources
+    page.evaluate_script(<<~JS)
+      Array.from(
+        document.querySelectorAll("#{description_editor_selector} .editor-input .ProseMirror img[src]")
+      ).map((image) => image.getAttribute("src"))
+    JS
+  end
+end


### PR DESCRIPTION
## Resumen

Este PR corrige un problema de compatibilidad en el editor WYSIWYG de Decidim 0.30.x al editar resultados de Accountability con contenido HTML legado que contiene imágenes sueltas en etiquetas `<p><img></p>`.

El cambio introduce una normalización previa del contenido en el `FormBuilder` para transformar esas imágenes al formato que espera el editor basado en Tiptap, envolviéndolas en contenedores `div[data-image]`. De este modo, el contenido histórico puede cargarse correctamente en el formulario de edición sin perder las imágenes.

## Cambios incluidos

- Se añade un inicializador con un normalizador de HTML legado para detectar imágenes no embebidas en data URI y convertirlas al formato compatible con el editor actual.
- Se aplica ese normalizador en el punto donde `Decidim::FormBuilder` construye el valor inicial del campo del editor.
- Se añade un test de sistema que reproduce un caso real de edición de un resultado de Accountability con varias imágenes remotas heredadas y verifica que el editor rehidrata todas las imágenes esperadas.

## Validación

- Se cubre el caso mediante un test de sistema con JavaScript sobre el formulario real del panel de administración.
- El test comprueba tanto el número de imágenes renderizadas en ProseMirror como que las URLs cargadas coinciden con las originales.